### PR TITLE
switch CI to listen for main branch instead of master

### DIFF
--- a/circle.sh
+++ b/circle.sh
@@ -2,7 +2,7 @@
 set -eu
 docker login -u="$DOCKER_USERNAME" -p="$DOCKER_PASSWORD"
 latest=
-if [ "$CIRCLE_BRANCH" = "master" ]; then
+if [ "$CIRCLE_BRANCH" = "main" ]; then
     latest=--latest
 fi
 bin/build --push $latest

--- a/travis.sh
+++ b/travis.sh
@@ -2,7 +2,7 @@
 docker login -u="$DOCKER_USERNAME" -p="$DOCKER_PASSWORD"
 set -eux
 latest=
-if [ "$TRAVIS_BRANCH" = "master" ] && [ "$TRAVIS_PULL_REQUEST" = "false" ]; then
+if [ "$TRAVIS_BRANCH" = "main" ] && [ "$TRAVIS_PULL_REQUEST" = "false" ]; then
     latest=--latest
 fi
 bin/build --push $latest


### PR DESCRIPTION
I went to use a feature flag (`hot_index_reload`) for `codesearch` that was implemented ~Apr 2020, running on `livegrep/base:latest` with Docker and got something like `this isn't a valid CLI flag` - however, it worked locally. 

Took a look at the [docker hub images for livegrep/base](https://hub.docker.com/r/livegrep/base/tags) and noticed that `latest` isn't the most recent build of `livegrep/base`. For example, `3b656eac93-0` was pushed 6 months ago, `latest` 1 year ago. 

GitHub switched to `main` ~Oct, 2020 - so my best guess is that the branch change prevented has prevented things from being tagged `latest` since then. 

Hope it's ok I opened a PR instead of an issue, if there's any questions or anything you'd like me to change, just let me know! Thanks for all your work on this project.  